### PR TITLE
Bug: Telegram keyboard not hiding after MSG–3B Price message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,65 @@
-// bugbot trigger
+# Запрос для BugBot: ReplyKeyboard не скрывается при отправке msg3B
+
+## Контекст
+Telegram бот на Node.js использует Telegraf v4.16.3. При отправке сообщения msg3B (Price message) в ветке B необходимо скрыть ReplyKeyboard, но она не скрывается.
+
+## Проблема
+Когда пользователь отправляет объявление и бот отвечает сообщением msg3B с inline-кнопками (строки ~968-988 в index.js), ReplyKeyboard остается видимой на экране пользователя. Ожидается, что она должна быть скрыта.
+
+## Технические детали
+- **Библиотека**: Telegraf v4.16.3
+- **Node.js**: (используется встроенный fetch Node.js 18+)
+- **Файл**: index.js, строки ~968-988 (для одиночных сообщений) и ~908-935 (для альбомов)
+
+## Текущий код (не работает)
+```javascript
+if (st.flow === 'B') {
+  // Агрессивное удаление ReplyKeyboard: сначала создаем, потом удаляем
+  const k1 = await ctx.reply('‎', {
+    disable_notification: true,
+    reply_markup: {
+      keyboard: [[{ text: '‎' }]],
+      resize_keyboard: true,
+      one_time_keyboard: true
+    }
+  }).catch(() => null);
+  
+  await new Promise(r => setTimeout(r, 100));
+  
+  const k2 = await ctx.reply('‎', {
+    disable_notification: true,
+    reply_markup: { remove_keyboard: true }
+  }).catch(() => null);
+  
+  // Отправляем msg3B с inline-кнопками
+  const keyboard = Markup.inlineKeyboard([
+    [Markup.button.callback(cfg.btnBFreePlacement || 'бесплатное размещение', 'b:freePlacement')],
+    [Markup.button.callback(cfg.btnBProceedMedia || 'Отправить медиа', 'b:proceedMedia')]
+  ]);
+  await ctx.reply(cfg.msg3B || 'Продолжим?', { ...keyboard, ...MSG_OPTS });
+  
+  // Удаляем служебные сообщения
+  setTimeout(() => {
+    if (k1) bot.telegram.deleteMessage(k1.chat.id, k1.message_id).catch(() => {});
+    if (k2) bot.telegram.deleteMessage(k2.chat.id, k2.message_id).catch(() => {});
+  }, 600);
+  return;
+}
+```
+
+## Что уже было испробовано
+1. ✅ Попытка объединить `inline_keyboard` и `remove_keyboard` в одном `reply_markup` - не работает (Telegram API не поддерживает)
+2. ✅ Отправка отдельного сообщения с `remove_keyboard: true` перед msg3B - не работает
+3. ✅ Агрессивный подход: создание временной ReplyKeyboard, затем удаление через 100ms - не работает
+
+## Важные детали
+- ReplyKeyboard появляется автоматически при вводе текста пользователем (это стандартное поведение Telegram клиентов)
+- Бот никогда явно не устанавливает ReplyKeyboard - она появляется автоматически от клиента Telegram
+- В коде есть функция `hideKeyboardAggressively` (строка 746), которая работает в других местах, но аналогичный подход здесь не помогает
+- Проблема возникает именно при отправке msg3B с inline-кнопками
+
+## Вопрос для BugBot
+Как правильно скрыть ReplyKeyboard при отправке сообщения с inline-кнопками в Telegraf v4? Возможно ли это вообще, если ReplyKeyboard была показана автоматически клиентом Telegram, а не установлена ботом явно?
+
+## Ожидаемое поведение
+При отправке msg3B ReplyKeyboard должна быть скрыта, а пользователь должен видеть только inline-кнопки под сообщением.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+// bugbot trigger

--- a/index.js
+++ b/index.js
@@ -909,7 +909,13 @@ bot.telegram.setChatMenuButton({
                   [Markup.button.callback(cfgNow.btnBFreePlacement || 'бесплатное размещение', 'b:freePlacement')],
                   [Markup.button.callback(cfgNow.btnBProceedMedia || 'Отправить медиа', 'b:proceedMedia')]
                 ]);
-                await bot.telegram.sendMessage(buf.fromChatId, cfgNow.msg3B || 'Продолжим?', { ...MSG_OPTS, ...keyboard });
+                await bot.telegram.sendMessage(buf.fromChatId, cfgNow.msg3B || 'Продолжим?', {
+                  reply_markup: { 
+                    remove_keyboard: true,
+                    ...keyboard.reply_markup
+                  },
+                  ...MSG_OPTS
+                });
               }
             }
           } finally {
@@ -948,7 +954,13 @@ bot.telegram.setChatMenuButton({
           [Markup.button.callback(cfg.btnBFreePlacement || 'бесплатное размещение', 'b:freePlacement')],
           [Markup.button.callback(cfg.btnBProceedMedia || 'Отправить медиа', 'b:proceedMedia')]
         ]);
-        await ctx.reply(cfg.msg3B || 'Продолжим?', { ...keyboard, ...MSG_OPTS });
+        await ctx.reply(cfg.msg3B || 'Продолжим?', {
+          reply_markup: { 
+            remove_keyboard: true,
+            ...keyboard.reply_markup
+          },
+          ...MSG_OPTS
+        });
         return;
       }
     }


### PR DESCRIPTION
@BugBot run

# Bug: ReplyKeyboard not hidden when sending msg3B (Price message)

## Context
- Stack: Node.js + Telegraf v4.16.3  
- Flow: Branch B (msg3B “Price” step)  
- Goal: when the bot sends msg3B (with inline buttons), the ReplyKeyboard should automatically hide.

## Problem
When a user submits a listing and the bot replies with msg3B (inline buttons), the ReplyKeyboard remains visible instead of collapsing.  
Expected: The ReplyKeyboard collapses (is removed), and only inline buttons are visible.

## File / location
- File: `index.js`
- Single-media path: lines ~968–988  
- Album path: lines ~908–935  

The relevant message is `ctx.reply(...)` that sends msg3B.

## What has been tried
1. Combining `inline_keyboard` and `remove_keyboard` in one `reply_markup` → not supported by Telegram.  
2. Sending a separate message with `{ remove_keyboard: true }` before msg3B → doesn’t work.  
3. “Aggressive” workaround: sending a temporary ReplyKeyboard and removing it after 100 ms → still visible.

## Important details
- The ReplyKeyboard appears automatically when the user types (Telegram client behavior).  
- The bot never explicitly sets ReplyKeyboard in this flow.  
- There’s a helper `hideKeyboardAggressively` (around line 746) that works elsewhere but fails here.  

## Question for BugBot
How can we reliably hide the ReplyKeyboard when sending msg3B with inline buttons in Telegraf v4?  
Is it possible if the keyboard was shown automatically by the Telegram client, not by the bot?

## Expected behavior
When msg3B is sent, the ReplyKeyboard should disappear completely and only inline buttons should remain visible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates msg3B sending to include remove_keyboard alongside inline buttons; adds README documenting the issue/context.
> 
> - **Bot (index.js)**:
>   - **Branch B msg3B**:
>     - Single-message path: `ctx.reply(...)` now sets `reply_markup` with `{ remove_keyboard: true, ...keyboard.reply_markup }` instead of spreading `keyboard` directly.
>     - Album path: `bot.telegram.sendMessage(...)` for msg3B uses the same `reply_markup` combination to collapse the ReplyKeyboard.
> - **Docs**:
>   - Add `README.md` outlining the ReplyKeyboard visibility issue, context, attempted fixes, and expected behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1723448e099b8e02e9070e906b49576e85f98a1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->